### PR TITLE
Add AgentServices — x402 paid data APIs for AI agents (MCP server, 37 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Cross-platform MCP servers and AI tooling that connect commerce data and actions
 - [PayPal Agent Toolkit](https://github.com/paypal/agent-toolkit) - Official PayPal toolkit for integrating commerce actions into AI agents.
 - [Stripe AI Toolkit](https://github.com/stripe/ai) - Official Stripe tooling and MCP server for building AI-powered payment agents.
 - [Stripe MCP Server](https://docs.stripe.com/mcp) - Official remote MCP server exposing Stripe payment operations to AI assistants.
+- [AgentServices](https://agentservices.to) - 54-service paid data API platform for AI agents with x402 micropayments — crypto market data, forex, stocks, news, IP geolocation, and 37 MCP tools.
 
 ## Shopify
 


### PR DESCRIPTION
## What is AgentServices?

[AgentServices](https://agentservices.to) is a production MCP server providing 54 data services to AI agents with x402 micropayments on Base (USDC). It exposes 37 MCP tools covering crypto market data, forex rates, stock prices, news, IP geolocation, DeFi yields, and more.

**Why it fits AI & MCP Servers:**
- Production MCP server (protocol `2026-07-28`, version 5.3.0)
- Listed on the [official MCP Registry](https://to.agentservices/agentservices)
- Uses x402 payment protocol for per-call micropayments (~$0.01/call)
- Gasless payments via CDP paymaster on Base L2
- 54 services, 41 paid via x402, 13 free

**Categories of data:**
- Crypto: prices, market data, DeFi yields, on-chain data
- Traditional finance: forex rates, stock prices, indices
- News & analytics: market news, global metrics
- Utilities: IP geolocation, image generation, chat completions

## Entry added

Under **AI & MCP Servers**, alongside PayPal Agent Toolkit and Stripe AI Toolkit:

```
- [AgentServices](https://agentservices.to) - 54-service paid data API platform for AI agents with x402 micropayments — crypto market data, forex, stocks, news, IP geolocation, and 37 MCP tools.
```

MCP handshake verified live: `https://agentservices.to/mcp` returns correct `InitializeResult` with server name `AgentServices`, version `5.3.0`.