### PR TITLE
Badge program: inbound badge loop for listed projects

### DIFF
--- a/.github/workflows/badge-comment.yml
+++ b/.github/workflows/badge-comment.yml
@@ -1,0 +1,33 @@
+name: Badge Comment
+
+on:
+  pull_request_target:
+    types: [closed]
+    paths:
+      - README.md
+
+permissions:
+  pull-requests: write
+
+jobs:
+  badge:
+    if: >
+      github.event.pull_request.merged == true &&
+      !contains(fromJSON('["conal-cpu", "leeknowsai", "github-actions[bot]"]'), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Thank contributor with badge snippet
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "Thanks for contributing, @${AUTHOR}! 🎉
+
+          If your project was added to the list, feel free to show it off with the badge:
+
+          [![Mentioned in Awesome Agentic Commerce](https://awesome.re/mentioned-badge.svg)](https://github.com/MentionNetwork/awesome-agentic-commerce)
+
+          \`\`\`markdown
+          [![Mentioned in Awesome Agentic Commerce](https://awesome.re/mentioned-badge.svg)](https://github.com/MentionNetwork/awesome-agentic-commerce)
+          \`\`\`"

--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -20,22 +20,21 @@ jobs:
         run: |
           set -euo pipefail
           SINCE=$(date -u -d '14 days ago' +%Y-%m-%d)
-          : > candidates.md
+          : > candidates.tsv
           for TOPIC in agentic-commerce acp ucp mcp-commerce ai-shopping; do
             gh api "search/repositories?q=topic:${TOPIC}+pushed:>${SINCE}&sort=stars&order=desc&per_page=10" \
-              --jq '.items[] | select(.stargazers_count >= 3) | "- [\(.full_name)](\(.html_url)) — ⭐\(.stargazers_count) — \(.description // "no description")"' \
-              >> candidates.md || true
+              --jq '.items[] | select(.stargazers_count >= 3) | [.full_name, .html_url, (.stargazers_count|tostring), .owner.login, .owner.type, (.description // "no description")] | @tsv' \
+              >> candidates.tsv || true
           done
           # drop repos already listed in the README, dedupe
-          sort -u candidates.md | while IFS= read -r line; do
-            url=$(echo "$line" | grep -oE 'https://github.com/[^)]+' | head -1)
-            [ -n "$url" ] && ! grep -qF "$url" README.md && echo "$line"
-          done > fresh.md || true
-          if [ -s fresh.md ]; then
+          sort -u candidates.tsv | while IFS=$'\t' read -r name url stars owner otype desc; do
+            [ -n "$url" ] && ! grep -qF "$url" README.md && printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$name" "$url" "$stars" "$owner" "$otype" "$desc"
+          done > fresh.tsv || true
+          if [ -s fresh.tsv ]; then
             {
               echo "Weekly scan found candidate repos not yet on the list. Review, verify quality, and PR the keepers."
               echo
-              cat fresh.md
+              awk -F'\t' '{printf "- [%s](%s) — ⭐%s — %s\n", $1, $2, $3, $6}' fresh.tsv
             } > body.md
             echo "FOUND=1" >> "$GITHUB_ENV"
           fi
@@ -49,3 +48,30 @@ jobs:
             --body-file body.md \
             --label submission \
             --repo "$GITHUB_REPOSITORY"
+      - name: Invite indie authors (max 3/week, never twice)
+        if: env.FOUND == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # indie filter: user-owned repo, 3-3000 stars; top 3 by stars
+          sort -t$'\t' -k3,3nr fresh.tsv \
+            | awk -F'\t' '$5 == "User" && $3+0 >= 3 && $3+0 <= 3000' \
+            | head -3 > invites.tsv || true
+          [ -s invites.tsv ] || exit 0
+          gh issue list --repo "$GITHUB_REPOSITORY" --label invitation --state all --limit 500 --json title --jq '.[].title' > invited.txt || true
+          while IFS=$'\t' read -r name url stars owner otype desc; do
+            TITLE="Invite: ${name}"
+            grep -qxF "$TITLE" invited.txt && continue
+            BODY="Hi @${owner} 👋 — our weekly scan surfaced [${name}](${url}) and it looks like a fit for [Awesome Agentic Commerce](https://github.com/MentionNetwork/awesome-agentic-commerce), a curated list for the agentic commerce space (protocols, GEO, agent-ready ecommerce).
+
+          If you'd like it listed, open a small PR following the [contribution guidelines](https://github.com/MentionNetwork/awesome-agentic-commerce/blob/main/contributing.md) — takes about 2 minutes, and listed projects are welcome to add the [Mentioned in Awesome badge](https://github.com/MentionNetwork/awesome-agentic-commerce/blob/main/contributing.md#badge-for-listed-projects).
+
+          Not interested? Just close this issue — we won't ping you again."
+            gh issue create \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label invitation \
+              --repo "$GITHUB_REPOSITORY"
+            sleep 5
+          done < invites.tsv

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ Marketing tooling — including Generative Engine Optimization (GEO), the practi
 
 Contributions are welcome! Read the [contribution guidelines](contributing.md) first.
 
+Listed here? Add the [Mentioned in Awesome badge](contributing.md#badge-for-listed-projects) to your README.
+
 ---
 
 Maintained by the team at [Mention Network](https://github.com/MentionNetwork), building AI visibility tools for ecommerce.

--- a/contributing.md
+++ b/contributing.md
@@ -31,3 +31,13 @@ Thanks for taking the time to contribute! Please make sure your suggestion is ge
 ## Reporting issues
 
 Found a dead link, a mislabeled entry, or a better alternative? Open an issue — housekeeping PRs are just as welcome as new entries.
+
+## Badge for listed projects
+
+Is your project on the list? Add the badge to your README:
+
+[![Mentioned in Awesome Agentic Commerce](https://awesome.re/mentioned-badge.svg)](https://github.com/MentionNetwork/awesome-agentic-commerce)
+
+```markdown
+[![Mentioned in Awesome Agentic Commerce](https://awesome.re/mentioned-badge.svg)](https://github.com/MentionNetwork/awesome-agentic-commerce)
+```


### PR DESCRIPTION
Turns the list into a self-serve badge loop:

1. **contributing.md** — new "Badge for listed projects" section with the standard awesome.re `Mentioned in Awesome` badge snippet; README Contributing section links to it.
2. **badge-comment.yml** (new) — when a contributor's PR touching README.md is merged, the bot comments with the badge snippet (skips maintainers/bots). Every new listed tool gets the badge offer automatically.
3. **discovery.yml** — after the weekly triage issue, invites up to 3 indie authors (user-owned repos, 3–3000 stars) via `invitation` issues @mentioning them; dedup by issue title so nobody is pinged twice; opt-out by closing the issue.

Goal: every newly listed project becomes a backlink + promoter without any outbound email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)